### PR TITLE
Support 201 status code

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -96,7 +96,7 @@ func getOuath2AuthAccessToken() {
 			continue
 		}
 
-		if resp.StatusCode != 200 {
+		if resp.StatusCode != 200 && resp.StatusCode != 201 {
 			log.Printf("Received non-200 status code: %s", resp.Status)
 			continue
 		}


### PR DESCRIPTION
Our Hydra based OAuth2 service returns a 201 status code instead of 200, after creating the token successful.